### PR TITLE
feat: add GET list groups endpoint

### DIFF
--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { DocumentsService } from './documents.service';
-import { GetListFilesDto } from './dto';
+import { GetListFilesDto, GetListGroupsDto } from './dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('documents')
@@ -11,5 +11,11 @@ export class DocumentsController {
   @Get()
   async getListFiles(@Query() getListFilesDto: GetListFilesDto) {
     return await this.documentsService.getListFiles(getListFilesDto.network);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/groups')
+  async getListGroups(@Query() getListGroupsDto: GetListGroupsDto) {
+    return await this.documentsService.getListGroups(getListGroupsDto.network);
   }
 }

--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -61,4 +61,50 @@ export class DocumentsService {
       );
     }
   }
+
+  async getListGroups(network: string) {
+    const pinataApiUrl =
+      this.configService.getOrThrow<string>('PINATA_API_URL');
+    const pinataJwtToken =
+      this.configService.getOrThrow<string>('PINATA_JWT_TOKEN');
+
+    try {
+      const options = {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${pinataJwtToken}`,
+        },
+      };
+
+      const rawResponse = await fetch(
+        `${pinataApiUrl}/groups/${network}`,
+        options,
+      );
+
+      if (!rawResponse.ok) {
+        this.logger.error(`Pinata API error: ${rawResponse.status}`);
+        throw new HttpException(
+          'Error fetching groups from pinata',
+          rawResponse.status,
+        );
+      }
+
+      const response = rawResponse.json();
+
+      return response;
+    } catch (error) {
+      this.logger.error(
+        `Failed to get list of groups for network ${network}: `,
+        error.stack,
+      );
+
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException(
+        'Could not retrieve group list due to an unexpected error.',
+      );
+    }
+  }
 }

--- a/src/documents/dto/get-list-groups.dto.ts
+++ b/src/documents/dto/get-list-groups.dto.ts
@@ -1,0 +1,10 @@
+import { IsEnum } from 'class-validator';
+
+enum Network {
+  PUBLIC = 'public',
+  PRIVATE = 'private',
+}
+export class GetListGroupsDto {
+  @IsEnum(Network, { message: 'Network must be either public or private' })
+  network: string;
+}

--- a/src/documents/dto/index.ts
+++ b/src/documents/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './get-list-files.dto';
+export * from './get-list-groups.dto';


### PR DESCRIPTION
This endpoint will return list of groups in IPFS. Query `network` is needed to get list whether in public or private network.